### PR TITLE
Add support for local Scenes in Compendiums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 sync.sh
+.idea
+.git
+*.iml

--- a/lang/en.json
+++ b/lang/en.json
@@ -21,6 +21,8 @@
   "mtte.imageURLToolTip": "Provide a link to the image (direct link)",
   "mtte.importScene": "Import scene",
   "mtte.importSceneToolTip": "Click to import the scene into your world",
+  "mtte.indexScenes": "Index scenes",
+  "mtte.indexScenesToolTip": "Moulinette will index Scene Compendia. You must re-index every time the Compendia change.",
   "mtte.learnMore": "to learn more about Moulinette and/or support it.",
   "mtte.license": "License",
   "mtte.preview": "See preview of the scene.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -21,6 +21,8 @@
   "mtte.imageURLToolTip": "Lien pour le t\u00e9l\u00e9chargement direct de l'image",
   "mtte.importScene": "Importer la sc\u00e8ne",
   "mtte.importSceneToolTip": "Importer la sc\u00e8ne dans votre monde",
+  "mtte.indexScenes": "Indexer les sc\u00e8nes",
+  "mtte.indexScenesToolTip": "Moulinette indexera les recueils de sc\u00e8nes. Vous devez r\u00e8indexer chaque fois que les Compendia changent.",
   "mtte.learnMore": "pour apprendre plus \u00e0 propos de Moulinette et/ou le supporter.",
   "mtte.license": "License",
   "mtte.preview": "Pr\u00e9visualiser la sc\u00e8ne.",

--- a/modules/moulinette-preview.js
+++ b/modules/moulinette-preview.js
@@ -145,7 +145,15 @@ export class MoulinettePreview extends FormApplication {
       }
       
       // adapt scene and create
-      const sceneData = JSON.parse(jsonAsText)
+
+      // ensure compendium is loaded before accessing it
+      if(this.asset.data.journalId && game.packs.get(this.asset.filename).size === 0) {
+        await game.packs.get(this.asset.filename)?.getDocuments();
+      }
+
+      const sceneData = this.asset.data.journalId ?
+          JSON.parse(JSON.stringify(game.packs.get(this.asset.filename).get(this.asset.data.journalId).data)) :
+          JSON.parse(jsonAsText);
       
       // configure dimensions if no width/height set
       if( !("width" in sceneData)) {

--- a/modules/moulinette-scenes.js
+++ b/modules/moulinette-scenes.js
@@ -4,6 +4,8 @@ import { MoulinettePreview } from "./moulinette-preview.js"
  * Forge Module for scenes
  */
 export class MoulinetteScenes extends game.moulinette.applications.MoulinetteForgeModule {
+  static FOLDER_MODULES  = "modules";
+  static FOLDER_CUSTOM_SCENES = "moulinette/scenes/custom";
 
   constructor() {
     super()
@@ -28,8 +30,8 @@ export class MoulinetteScenes extends game.moulinette.applications.MoulinetteFor
     const user = await game.moulinette.applications.Moulinette.getUser()
     const index = await game.moulinette.applications.MoulinetteFileUtil.buildAssetIndex([
       game.moulinette.applications.MoulinetteClient.SERVER_URL + "/assets/" + game.moulinette.user.id,
-      game.moulinette.applications.MoulinetteFileUtil.getBaseURL() + "moulinette/images/custom/index.json"])
-    
+      game.moulinette.applications.MoulinetteFileUtil.getBaseURL() + "moulinette/scenes/custom/index.json"])
+
     // remove non-scene
     this.assets = index.assets.filter(a => {
       if(a.type == "scene" && a.filename.endsWith(".webp")) {
@@ -47,14 +49,14 @@ export class MoulinetteScenes extends game.moulinette.applications.MoulinetteFor
     
     // sort assets
     this.assets.sort((a, b) => (a.data.name > b.data.name) ? 1 : -1)
-    
+
     return duplicate(this.assetsPacks)
   }
   
   /**
    * Generate a new asset (HTML) for the given result and idx
    */
-  generateAsset(r, idx) {
+  async generateAsset(r, idx) {
     const pack = this.assetsPacks[r.pack]
     const URL = pack.isLocal || pack.isRemote ? "" : game.moulinette.applications.MoulinetteFileUtil.getBaseURL()
     
@@ -65,10 +67,16 @@ export class MoulinetteScenes extends game.moulinette.applications.MoulinetteFor
     const basePath = r.data.img.substring(0, r.data.img.lastIndexOf('.'))
     r.baseURL = `${URL}${pack.path}/${basePath}`
     
-    // thumb is always same as image path but with _thumb appended
+    // thumb is always same as image path but with _thumb appended, except for local scenes which have thumb stored in compendium .db
     const filename = r.filename.split('/').pop().replace(/_/g, " ").replace(/-/g, " ").replace(".json", "")
-    let html = `<div class="scene" title="${r.data.name}\n(${filename})" data-idx="${idx}" data-path="${r.filename}"><img width="200" height="200" src="${r.baseURL}_thumb.webp${r.sas}"/>`
-    html += `<div class="text">${filename}</div><div class="includes">`
+    const displayName = pack.isLocal ? r.data.name : filename;
+    // ensure compendium is loaded before accessing it
+    if(pack.isLocal && game.packs.get(r.filename).size === 0) {
+       await game.packs.get(r.filename)?.getDocuments();
+    }
+    const thumbSrc = pack.isLocal ? game.packs.get(r.filename).get(r.data.journalId).data.thumb : `${r.baseURL}_thumb.webp${r.sas}`;
+    let html = `<div class="scene" title="${r.data.name}\n(${filename})" data-idx="${idx}" data-path="${r.filename}"><img width="200" height="200" src="${thumbSrc}"/>`
+    html += `<div class="text">${displayName}</div><div class="includes">`
     if(r.data.walls) html += `<div class="info"><i class="fas fa-university"></i></div>`
     if(r.data.lights) html += `<div class="info"><i class="far fa-lightbulb"></i></div>`
     if(r.data.sounds) html += `<div class="info"><i class="fas fa-music"></i></div>`
@@ -102,7 +110,7 @@ export class MoulinetteScenes extends game.moulinette.applications.MoulinetteFor
       if( publisher && publisher != this.assetsPacks[t.pack].publisher ) return false
       // check if text match
       for( const f of searchTerms ) {
-        if( t.filename.toLowerCase().indexOf(f) < 0 ) return false
+        if( t.data.name.toLowerCase().indexOf(f) < 0 && t.filename.toLowerCase().indexOf(f) < 0 ) return false
       }
       return true;
     })
@@ -114,7 +122,7 @@ export class MoulinetteScenes extends game.moulinette.applications.MoulinetteFor
       let idx = 0
       for(const r of this.searchResults) {
         idx++
-        assets.push(this.generateAsset(r, idx))
+        assets.push(await this.generateAsset(r, idx))
       }
     }
     // view #2 (by folder)
@@ -169,5 +177,106 @@ export class MoulinetteScenes extends game.moulinette.applications.MoulinetteFor
       new MoulinettePreview(duplicate(result), duplicate(this.assetsPacks[result.pack])).render(true)
     }
   }
-  
+
+  static async scanScenes(sourcePath) {
+    const MoulinetteFileUtil = game.moulinette.applications.MoulinetteFileUtil;
+
+    const debug = game.settings.get("moulinette-core", "debugScanAssets");
+    const source = MoulinetteFileUtil.getSource();
+    // read publisher info from module.json
+    let publishers = []
+    if(debug) console.log(`Moulinette FileUtil | Root: scanning ${sourcePath} ...`)
+    let dir1 = await FilePicker.browse(source, sourcePath, MoulinetteFileUtil.getOptions());
+    if(debug) console.log(`Moulinette FileUtil | Root: ${dir1.dirs.length} subfolders found.`)
+
+    // stop scanning if ignore.info file found
+    if(dir1.files.find(f => f.endsWith("/ignore.info"))) {
+      if(debug) console.log(`Moulinette FileUtil | File ignore.info found. Stop scanning.`)
+      return publishers;
+    }
+
+    for(const publisher of dir1.dirs) {
+      if(debug) console.log(`Moulinette FileUtil | Root: processing publisher ${publisher}...`)
+      let dirPub = await FilePicker.browse(source, publisher, MoulinetteFileUtil.getOptions());
+      let moduleJson = dirPub.files.find(f => f.endsWith('module.json'));
+      if(!moduleJson) {
+        continue;
+      }
+      const response = await fetch(moduleJson).catch(function(e) {
+        if(debug) console.log(`Moulinette | Not able to fetch module JSON`, e)
+      });
+      const moduleJsonContent = await response.json();
+      const scenePacks = moduleJsonContent?.packs?.filter(p => p.entity === 'Scene');
+      if(scenePacks?.length > 0) {
+        let packs = [];
+
+        for(let scenePack of scenePacks) {
+          const packname= `${moduleJsonContent.name}.${scenePack.name}`;
+          // get matching compendium and add it's scenes
+          const scenes = await game.packs.get(packname)?.getDocuments();
+          if(!scenes) {
+            continue;
+          }
+
+          const pack = {
+            "isLocal": true,
+            "assets":[],
+            "deps":[],
+            "license":"\u00a9 " + moduleJsonContent.author,
+            "licenseUrl":moduleJsonContent.url,
+            "name":scenePack.label,
+            "path":publisher,
+            "sas":null,
+            "showCase":true,
+            "url":moduleJsonContent.url
+          }
+
+          for(let scene of scenes) {
+            if(scene.data.img) {
+              pack.assets.push(
+                  {
+                    "deps":[
+                      scene.data.img
+                    ],
+                    "drawings":scene.data.drawings.size > 0,
+                    "eDeps":{},
+                    "img":scene.data.img,
+                    "lights":scene.data.lights.size > 0,
+                    "name":scene.data.name,
+                    "journalId":scene.id,
+                    "path":packname,
+                    "sounds":scene.data.sounds.size > 0,
+                    "type":"scene",
+                    "walls":scene.data.walls.size > 0
+                    // don't save thumb - too large size
+                  }
+              );
+            }
+          }
+          packs.push(pack);
+        }
+
+        publishers.push({
+          publisher: moduleJsonContent.author,
+          website: moduleJsonContent.url,
+          packs
+        })
+      }
+    }
+    return publishers
+  }
+
+  async onAction(classList) {
+    const FileUtil = game.moulinette.applications.MoulinetteFileUtil;
+    if(classList.contains("indexScenes")) {
+      ui.notifications.info(game.i18n.localize("mtte.indexingInProgress"));
+      this.html.find(".indexScenes").prop("disabled", true);
+      let publishers = await MoulinetteScenes.scanScenes(MoulinetteScenes.FOLDER_MODULES);
+      await FileUtil.uploadFile(new File([JSON.stringify(publishers)], "index.json", { type: "application/json", lastModified: new Date() }), "index.json", MoulinetteScenes.FOLDER_CUSTOM_SCENES, true)
+      ui.notifications.info(game.i18n.localize("mtte.indexingDone"));
+      game.moulinette.cache.clear()
+      this.clearCache()
+      return true
+    }
+  }
 }

--- a/moulinette-scenes.js
+++ b/moulinette-scenes.js
@@ -14,7 +14,7 @@ Hooks.once("init", async function () {
 Hooks.once("ready", async function () {
   if (game.user.isGM) {
     // create default home folder for scenes
-    await game.moulinette.applications.MoulinetteFileUtil.createFolderRecursive("moulinette/scenes");
+    await game.moulinette.applications.MoulinetteFileUtil.createFolderRecursive("moulinette/scenes/custom")
     
     const moduleClass = (await import("./modules/moulinette-scenes.js")).MoulinetteScenes
     game.moulinette.forge.push({
@@ -23,7 +23,9 @@ Hooks.once("ready", async function () {
       name: game.i18n.localize("mtte.scenes"),
       description: game.i18n.localize("mtte.scenesDescription"),
       instance: new moduleClass(),
-      actions: []
+      actions: [
+        {id: "indexScenes", icon: "fas fa-sync" ,name: game.i18n.localize("mtte.indexScenes"), help: game.i18n.localize("mtte.indexScenesToolTip") }
+      ]
     })
     
     console.log("Moulinette Scenes | Module loaded")

--- a/templates/preview.hbs
+++ b/templates/preview.hbs
@@ -1,7 +1,11 @@
 <form autocomplete="off" onsubmit="event.preventDefault();">
   <h3>{{pretty asset.data.name}} <small>({{filename}})</small></h3>
   <div class="scene">
-    <img id="previewImage" width="400" height="400" src="{{asset.baseURL}}.webp{{asset.sas}}" />
+    {{#if pack.isLocal}}
+        <img id="previewImage" width="400" height="400" src="{{asset.data.img}}" />
+    {{else}}
+        <img id="previewImage" width="400" height="400" src="{{asset.baseURL}}.webp{{asset.sas}}" />
+    {{/if}}
   </div>
   <p>  
     <i>Search provided by <a href="https://www.patreon.com/moulinette">Moulinette</a>.</i>


### PR DESCRIPTION
This adds local scenes from modules activate in the world into Moulinette search. The local scenes behave almost the same as remote scenes - they have drawins, lightning etc. marked if available. The author data is read from module.json, since it's lacking in compendium. The scenes are imported to Moulinette subfolder as remote scenes would be. The scenes can be searched along their remote counterparts, so Moulinette can be used to manage all scenes - both those obtained trough Patreon, and those bought on separate stores.

The biggest difference is thumbnail, which unfortunately is stored only as small banner. Also, due to lazy init of Compendiums and necessity to access thumbnails from those first search for some queries might take longer time to display.