### PR TITLE
Resolving Error

### DIFF
--- a/modules/moulinette-preview.js
+++ b/modules/moulinette-preview.js
@@ -116,7 +116,7 @@ export class MoulinettePreview extends FormApplication {
       this.assetURL = this.asset.data.img
     } else {
       const assetURL = this.pack.path ? `${this.pack.path}/${this.asset.data.img}` : this.asset.data.img
-      this.assetURL = assetURL.startsWith("http") ? assetURL : baseURL = assetURL
+      this.assetURL = assetURL.startsWith("http") ? assetURL : baseURL + assetURL
 
     }
 


### PR DESCRIPTION
We found that there was an error:
Assignment to constant variable.
[Detected 1 package: moulinette-scenes]
    at MoulinettePreview.getData (moulinette-preview.js:119:72)
    at async MoulinettePreview._render (foundry.js:5108:18)
    at async MoulinettePreview._render (foundry.js:5822:5)

This was due to a mistake where a constant variable was overwritten.
Looks like a typo to me, so I fixed it and tested it.